### PR TITLE
Add free_only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@
     # M-Team配置示例，请自行替换x-api-key参数
     [[sites]]
     name = "M-Team"
+    [sites.options]
+    free_only = false  # 是否只下载免费种子，默认false
     [[sites.headers]]
     key = "x-api-key"
     value = "xxxxx"

--- a/ptbrush/config/config.example.toml
+++ b/ptbrush/config/config.example.toml
@@ -31,6 +31,10 @@ password = ""
 # M-Team配置示例，请自行替换x-api-key参数
 [[sites]]
 name = "M-Team"
+
+[sites.options]
+free_only = false
+
 [[sites.headers]]
 key = "x-api-key"
 value = "xxxxx"

--- a/ptbrush/config/config.py
+++ b/ptbrush/config/config.py
@@ -18,10 +18,13 @@ class HeaderParam(BaseModel):
     key: str
     value: str
 
+class OptionParam(BaseModel):
+    free_only: Optional[bool] = False  # 是否只获取免费种子
 
 class SiteModel(BaseModel):
     name: str
     cookie: Optional[str] = ""
+    options: Optional[OptionParam] = OptionParam()
     headers: Optional[List[HeaderParam]] = []
 
 

--- a/ptbrush/ptsite/__init__.py
+++ b/ptbrush/ptsite/__init__.py
@@ -11,13 +11,14 @@ from typing import Any, Generator, List
 
 import requests
 
-from config.config import HeaderParam
+from config.config import HeaderParam, OptionParam
 from model import Torrent
 
 
 class BaseSiteSpider:
 
-    def __init__(self, cookie: str, headers: List[HeaderParam] = []):
+    def __init__(self, cookie: str, headers: List[HeaderParam] = [], options: OptionParam = OptionParam()):
+        self.options = options
         self.cookie = cookie
         # self.headers = headers
         self.headers = {
@@ -57,8 +58,9 @@ class TorrentFetch:
 
     SITE_SPIDER_MAP = {"M-Team": MTeamSpider}
 
-    def __init__(self, site: str, cookie: str, headers: List[HeaderParam] = []):
+    def __init__(self, site: str, cookie: str, headers: List[HeaderParam] = [], options: OptionParam = OptionParam()):
         self.site = site
+        self.options = options
         self.cookie = cookie
         self.headers = headers
         spider_class = self.SITE_SPIDER_MAP.get(self.site)
@@ -66,7 +68,7 @@ class TorrentFetch:
             raise ValueError(f"Unknown site: {self.site}")
 
         self._spider_class: BaseSiteSpider = spider_class(
-            self.cookie, self.headers)
+            self.cookie, self.headers, self.options)
 
     @property
     def free_torrents(self) -> Generator[Torrent, Torrent, Torrent]:

--- a/ptbrush/ptsite/mteam.py
+++ b/ptbrush/ptsite/mteam.py
@@ -111,7 +111,7 @@ class MTeamSpider(BaseSiteSpider):
         """
         if item.get("status").get("discount") in ["FREE", "_2X_FREE"]:
             return True
-        if item.get("status").get("toppingLevel") == "1":
+        if not self.options.free_only and item.get("status").get("toppingLevel") == "1":
             return True
         return False
 

--- a/ptbrush/tasks/services.py
+++ b/ptbrush/tasks/services.py
@@ -33,7 +33,7 @@ class PtTorrentService():
         for site in sites:
             logger.debug(f'开始处理站点:{site.name}')
             torrent_fetcher = TorrentFetch(
-                site.name, cookie=site.cookie, headers=site.headers
+                site.name, cookie=site.cookie, headers=site.headers, options=site.options
             )
             for torrent in torrent_fetcher.free_torrents:
                 logger.debug(f"从{site.name}抓取到种子: {torrent.name}")


### PR DESCRIPTION
## Summary by Sourcery

Add a 'free_only' option to allow users to filter and download only free torrents, and update the relevant classes and documentation to support this feature.

New Features:
- Introduce an option 'free_only' to filter and download only free torrents.

Enhancements:
- Enhance the TorrentFetch and BaseSiteSpider classes to support the new 'free_only' option.

Documentation:
- Update README.md to document the new 'free_only' option in the configuration.